### PR TITLE
Add Protocol V5 support for mod v5.0.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode/
+
 # User-specific stuff
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Download from Modrinth: https://modrinth.com/plugin/female-gender-spigot
 |:--------:|:-------------:|
 |    2     | 2.8.1 - 3.0.1 |
 |    3     | 3.1.0 - 4.0.0 |
-|    4     | 4.0.0 - ?.?.? |
+|    4     | 4.0.0 - 4.3.4 |
+|    5     | 5.0.0 - ?.?.? |
 
 Setting this value to -1 will try using the newest known protocol, useful so you don't need to change this manually
 every time you update the mod and plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 
     <groupId>dbrighthd</groupId>
     <artifactId>Female-Gender-Mod-Plugin</artifactId>
-    <version>1.4.3.1</version>
+    <version>1.5.0</version>
     <name>Female-Gender-Mod-Plugin</name>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -37,12 +37,24 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>24.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/networking/NetworkManager.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/networking/NetworkManager.java
@@ -28,7 +28,8 @@ public class NetworkManager {
                 1, new ModSyncPacketV1(),
                 2, new ModSyncPacketV2(),
                 3, new ModSyncPacketV3(),
-                4, new ModSyncPacketV4()
+                4, new ModSyncPacketV4(),
+                5, new ModSyncPacketV5()
         );
     }
 
@@ -38,7 +39,7 @@ public class NetworkManager {
 
     public boolean init() {
         int protocolVersion = plugin.getConfig().getInt("mod.protocol", -1);
-        packetFormat = protocolVersion == -1 ? PACKET_FORMATS.get(4)
+        packetFormat = protocolVersion == -1 ? PACKET_FORMATS.get(5)
                 : PACKET_FORMATS.get(protocolVersion);
         if (packetFormat == null) return false;
 

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV2.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV2.java
@@ -46,7 +46,8 @@ public class ModSyncPacketV2 implements ModSyncPacket {
         return new ModUser(userId, new ModConfiguration(
                 generalBuilder.create(),
                 physicsBuilder.create(),
-                breastBuilder.create()
+                breastBuilder.create(),
+                null
         ));
     }
 

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV3.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV3.java
@@ -45,7 +45,8 @@ public class ModSyncPacketV3 implements ModSyncPacket {
         return new ModUser(userId, new ModConfiguration(
                 generalBuilder.create(),
                 physicsBuilder.create(),
-                breastBuilder.create()
+                breastBuilder.create(),
+                null
         ));
     }
 

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV4.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV4.java
@@ -19,7 +19,7 @@ public class ModSyncPacketV4 implements ModSyncPacket {
 
     @Override
     public String getModRange() {
-        return "4.0.1 - ?.?.?";
+        return "4.0.1 - 4.3.4";
     }
 
     @Override
@@ -46,8 +46,8 @@ public class ModSyncPacketV4 implements ModSyncPacket {
         return new ModUser(userId, new ModConfiguration(
                 generalBuilder.create(),
                 physicsBuilder.create(),
-                breastBuilder.create()
-        ));
+                breastBuilder.create(),
+                null));
     }
 
     @Override

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV5.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/networking/wildfire/ModSyncPacketV5.java
@@ -1,0 +1,156 @@
+package dbrighthd.wildfiregendermodplugin.networking.wildfire;
+
+import dbrighthd.wildfiregendermodplugin.networking.minecraft.CraftInputStream;
+import dbrighthd.wildfiregendermodplugin.networking.minecraft.CraftOutputStream;
+import dbrighthd.wildfiregendermodplugin.wildfire.ModUser;
+import dbrighthd.wildfiregendermodplugin.wildfire.setup.*;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ModSyncPacketV5 implements ModSyncPacket {
+    @Override
+    public int getVersion() {
+        return 5;
+    }
+
+    @Override
+    public String getModRange() {
+        return "5.0.0 - ?.?.?";
+    }
+
+    @Override
+    public ModUser read(CraftInputStream input) throws IOException {
+        GeneralOptions.Builder generalBuilder = new GeneralOptions.Builder();
+        PhysicsOptions.Builder physicsBuilder = new PhysicsOptions.Builder();
+        BreastOptions.Builder breastBuilder = new BreastOptions.Builder();
+
+        UUID userId = input.readUUID();
+        generalBuilder.setGenderIdentity(input.readEnum(GenderIdentities.class));
+        breastBuilder.setBustSize(input.readFloat());
+        generalBuilder.setHurtSounds(input.readBoolean());
+        generalBuilder.setVoicePitch(input.readFloat());
+
+        // Physics record
+        physicsBuilder.setBreastPhysics(input.readBoolean());
+        boolean showInArmor = input.readBoolean();
+        generalBuilder.setShowInArmor(showInArmor);
+        physicsBuilder.setArmorPhysics(showInArmor);
+        physicsBuilder.setBuoyancy(input.readFloat()); // Now bounceMultiplier
+        physicsBuilder.setFloppiness(input.readFloat()); // Now floppyMultiplier
+
+        // Breasts record
+        breastBuilder.setXOffset(input.readFloat());
+        breastBuilder.setYOffset(input.readFloat());
+        breastBuilder.setZOffset(input.readFloat());
+        breastBuilder.setUniBoob(input.readBoolean());
+        breastBuilder.setCleavage(input.readFloat());
+
+        // UV Layouts
+        UVLayouts uvLayouts = readUVLayouts(input);
+
+        return new ModUser(userId, new ModConfiguration(
+                generalBuilder.create(),
+                physicsBuilder.create(),
+                breastBuilder.create(),
+                uvLayouts));
+    }
+
+    @Override
+    public void write(ModUser user, CraftOutputStream output) throws IOException {
+        ModConfiguration configuration = user.configuration();
+        GeneralOptions general = configuration.generalOptions();
+        PhysicsOptions physics = configuration.physicsOptions();
+        BreastOptions breast = configuration.breastOptions();
+        UVLayouts uvLayouts = configuration.uvLayouts();
+
+        output.writeUUID(user.userId());
+        output.writeEnum(general.genderIdentity());
+        output.writeFloat(breast.bustSize());
+        output.writeBoolean(general.hurtSounds());
+        output.writeFloat(general.voicePitch());
+
+        // Physics record
+        output.writeBoolean(physics.breastPhysics());
+        output.writeBoolean(general.showInArmor());
+        output.writeFloat(physics.buoyancy());
+        output.writeFloat(physics.floppiness());
+
+        // Breasts record
+        output.writeFloat(breast.xOffset());
+        output.writeFloat(breast.yOffset());
+        output.writeFloat(breast.zOffset());
+        output.writeBoolean(breast.uniBoob());
+        output.writeFloat(breast.cleavage());
+
+        // UV Layouts
+        writeUVLayouts(uvLayouts, output);
+    }
+
+    private UVLayouts readUVLayouts(CraftInputStream input) throws IOException {
+        UVLayouts.Layer skin = readLayer(input);
+        UVLayouts.Layer overlay = readLayer(input);
+        return new UVLayouts(skin, overlay);
+    }
+
+    private UVLayouts.Layer readLayer(CraftInputStream input) throws IOException {
+        UVLayout left = readUVLayout(input);
+        UVLayout right = readUVLayout(input);
+        return new UVLayouts.Layer(left, right);
+    }
+
+    private UVLayout readUVLayout(CraftInputStream input) throws IOException {
+        int count = input.readVarInt();
+        Map<UVDirection, UVQuad> quads = new EnumMap<>(UVDirection.class);
+        for (int i = 0; i < count; i++) {
+            UVDirection direction = UVDirection.byId(input.readVarInt());
+            UVQuad quad = new UVQuad(
+                    input.readVarInt(),
+                    input.readVarInt(),
+                    input.readVarInt(),
+                    input.readVarInt());
+            quads.put(direction, quad);
+        }
+        return new UVLayout(quads);
+    }
+
+    private void writeUVLayouts(UVLayouts layouts, CraftOutputStream output) throws IOException {
+        if (layouts == null) {
+            // Write empty layouts if null
+            writeLayer(null, output);
+            writeLayer(null, output);
+            return;
+        }
+        writeLayer(layouts.skin(), output);
+        writeLayer(layouts.overlay(), output);
+    }
+
+    private void writeLayer(UVLayouts.Layer layer, CraftOutputStream output) throws IOException {
+        if (layer == null) {
+            writeUVLayout(null, output);
+            writeUVLayout(null, output);
+            return;
+        }
+        writeUVLayout(layer.left(), output);
+        writeUVLayout(layer.right(), output);
+    }
+
+    private void writeUVLayout(UVLayout layout, CraftOutputStream output) throws IOException {
+        if (layout == null || layout.getQuads() == null) {
+            output.writeVarInt(0);
+            return;
+        }
+        Map<UVDirection, UVQuad> quads = layout.getQuads();
+        output.writeVarInt(quads.size());
+        for (Map.Entry<UVDirection, UVQuad> entry : quads.entrySet()) {
+            output.writeVarInt(entry.getKey().ordinal());
+            UVQuad quad = entry.getValue();
+            output.writeVarInt(quad.x1());
+            output.writeVarInt(quad.y1());
+            output.writeVarInt(quad.x2());
+            output.writeVarInt(quad.y2());
+        }
+    }
+}

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/ModConfiguration.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/ModConfiguration.java
@@ -7,5 +7,6 @@ package dbrighthd.wildfiregendermodplugin.wildfire.setup;
  */
 public record ModConfiguration(GeneralOptions generalOptions,
                                PhysicsOptions physicsOptions,
-                               BreastOptions breastOptions) {
+                               BreastOptions breastOptions,
+                               UVLayouts uvLayouts) {
 }

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVDirection.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVDirection.java
@@ -1,0 +1,14 @@
+package dbrighthd.wildfiregendermodplugin.wildfire.setup;
+
+public enum UVDirection {
+    EAST,
+    WEST,
+    DOWN,
+    UP,
+    NORTH;
+
+    public static UVDirection byId(int id) {
+        if (id < 0 || id >= values().length) return NORTH;
+        return values()[id];
+    }
+}

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVLayout.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVLayout.java
@@ -1,0 +1,24 @@
+package dbrighthd.wildfiregendermodplugin.wildfire.setup;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class UVLayout {
+    private final Map<UVDirection, UVQuad> quads;
+
+    public UVLayout() {
+        this.quads = new EnumMap<>(UVDirection.class);
+    }
+
+    public UVLayout(Map<UVDirection, UVQuad> quads) {
+        this.quads = new EnumMap<>(quads);
+    }
+
+    public Map<UVDirection, UVQuad> getQuads() {
+        return quads;
+    }
+
+    public void setQuad(UVDirection direction, UVQuad quad) {
+        quads.put(direction, quad);
+    }
+}

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVLayouts.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVLayouts.java
@@ -1,0 +1,6 @@
+package dbrighthd.wildfiregendermodplugin.wildfire.setup;
+
+public record UVLayouts(Layer skin, Layer overlay) {
+    public record Layer(UVLayout left, UVLayout right) {
+    }
+}

--- a/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVQuad.java
+++ b/src/main/java/dbrighthd/wildfiregendermodplugin/wildfire/setup/UVQuad.java
@@ -1,0 +1,4 @@
+package dbrighthd.wildfiregendermodplugin.wildfire.setup;
+
+public record UVQuad(int x1, int y1, int x2, int y2) {
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Female-Gender-Mod-Plugin
 version: '${project.version}'
 main: dbrighthd.wildfiregendermodplugin.GenderModPlugin
-api-version: 1.20
+api-version: '1.21'
 authors: [ 'dbrighthd', 'Stigstille', 'winnpixie' ]

--- a/src/test/java/dbrighthd/wildfiregendermodplugin/networking/ProtocolTest.java
+++ b/src/test/java/dbrighthd/wildfiregendermodplugin/networking/ProtocolTest.java
@@ -1,0 +1,127 @@
+package dbrighthd.wildfiregendermodplugin.networking;
+
+import dbrighthd.wildfiregendermodplugin.networking.minecraft.CraftInputStream;
+import dbrighthd.wildfiregendermodplugin.networking.wildfire.ModSyncPacketV5;
+import dbrighthd.wildfiregendermodplugin.wildfire.ModUser;
+import dbrighthd.wildfiregendermodplugin.wildfire.setup.GenderIdentities;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProtocolTest {
+        @Test
+        public void testV5Parsing() throws IOException {
+                // Sample V5 packet captured from research:
+                // UUID: 00000000-0000-0000-0000-000000000000
+                // Gender: FEMALE
+                // Bust: 0.5f
+                // HurtSounds: true
+                // VoicePitch: 1.0f
+                // Physics: (true, true, 1.0f, 1.0f)
+                // Breasts: (0.0f, 0.0f, 0.0f, false, 0.0f)
+                // UV Layouts: Empty layers (0 items in map)
+
+                byte[] data = new byte[] {
+                                // UUID (2 longs = 16 bytes)
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                // Gender (FEMALE = index 0)
+                                0x00,
+                                // BustSize (0.5f)
+                                0x3F, 0x00, 0x00, 0x00,
+                                // HurtSounds (true)
+                                0x01,
+                                // VoicePitch (1.0f)
+                                0x3F, (byte) 0x80, 0x00, 0x00,
+                                // Physics (true, true, 1.0f, 1.0f)
+                                0x01, 0x01,
+                                0x3F, (byte) 0x80, 0x00, 0x00,
+                                0x3F, (byte) 0x80, 0x00, 0x00,
+                                // Breasts (0.0f, 0.0f, 0.0f, false, 0.0f)
+                                0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00,
+                                0x00,
+                                0x00, 0x00, 0x00, 0x00,
+                                // UV Layouts (Skin: Left count=0, Right count=0; Overlay: Left count=0, Right
+                                // count=0)
+                                0x00, 0x00, 0x00, 0x00
+                };
+
+                ModSyncPacketV5 packet = new ModSyncPacketV5();
+                try (CraftInputStream input = CraftInputStream.ofBytes(data)) {
+                        ModUser user = packet.read(input);
+                        assertNotNull(user);
+                        assertEquals(new UUID(0, 0), user.userId());
+                        assertEquals(GenderIdentities.FEMALE, user.configuration().generalOptions().genderIdentity());
+                        assertEquals(0.5f, user.configuration().breastOptions().bustSize());
+                        assertTrue(user.configuration().generalOptions().hurtSounds());
+                        assertEquals(1.0f, user.configuration().generalOptions().voicePitch());
+                        assertTrue(user.configuration().physicsOptions().breastPhysics());
+                        assertTrue(user.configuration().generalOptions().showInArmor());
+                        assertEquals(1.0f, user.configuration().physicsOptions().buoyancy());
+                        assertEquals(1.0f, user.configuration().physicsOptions().floppiness());
+                        assertNotNull(user.configuration().uvLayouts());
+                }
+        }
+
+        @Test
+        public void testV5RoundTrip() throws IOException {
+                java.util.Map<dbrighthd.wildfiregendermodplugin.wildfire.setup.UVDirection, dbrighthd.wildfiregendermodplugin.wildfire.setup.UVQuad> quads = new java.util.EnumMap<>(
+                                dbrighthd.wildfiregendermodplugin.wildfire.setup.UVDirection.class);
+                quads.put(dbrighthd.wildfiregendermodplugin.wildfire.setup.UVDirection.NORTH,
+                                new dbrighthd.wildfiregendermodplugin.wildfire.setup.UVQuad(1, 2, 3, 4));
+
+                dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayout layout = new dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayout(
+                                quads);
+                dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayouts.Layer layer = new dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayouts.Layer(
+                                layout, layout);
+                dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayouts uvLayouts = new dbrighthd.wildfiregendermodplugin.wildfire.setup.UVLayouts(
+                                layer, layer);
+
+                dbrighthd.wildfiregendermodplugin.wildfire.setup.ModConfiguration config = new dbrighthd.wildfiregendermodplugin.wildfire.setup.ModConfiguration(
+                                new dbrighthd.wildfiregendermodplugin.wildfire.setup.GeneralOptions(
+                                                GenderIdentities.MALE, true, 1.2f,
+                                                true),
+                                new dbrighthd.wildfiregendermodplugin.wildfire.setup.PhysicsOptions(true, true, 0.8f,
+                                                0.9f),
+                                new dbrighthd.wildfiregendermodplugin.wildfire.setup.BreastOptions(0.7f, 0.1f, 0.2f,
+                                                0.3f, true, 0.4f),
+                                uvLayouts);
+
+                UUID userId = UUID.randomUUID();
+                ModUser user = new ModUser(userId, config);
+                ModSyncPacketV5 packet = new ModSyncPacketV5();
+
+                byte[] serialized;
+                try (java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream();
+                                dbrighthd.wildfiregendermodplugin.networking.minecraft.CraftOutputStream out = new dbrighthd.wildfiregendermodplugin.networking.minecraft.CraftOutputStream(
+                                                bytes)) {
+                        packet.write(user, out);
+                        serialized = bytes.toByteArray();
+                }
+
+                ModUser deserialized;
+                try (CraftInputStream in = CraftInputStream.ofBytes(serialized)) {
+                        deserialized = packet.read(in);
+                }
+
+                assertEquals(userId, deserialized.userId());
+                assertEquals(GenderIdentities.MALE, deserialized.configuration().generalOptions().genderIdentity());
+                assertEquals(0.7f, deserialized.configuration().breastOptions().bustSize());
+                assertEquals(0.8f, deserialized.configuration().physicsOptions().buoyancy());
+
+                assertNotNull(deserialized.configuration().uvLayouts());
+                dbrighthd.wildfiregendermodplugin.wildfire.setup.UVQuad quad = deserialized.configuration().uvLayouts()
+                                .skin()
+                                .left().getQuads()
+                                .get(dbrighthd.wildfiregendermodplugin.wildfire.setup.UVDirection.NORTH);
+                assertNotNull(quad);
+                assertEquals(1, quad.x1());
+                assertEquals(2, quad.y1());
+                assertEquals(3, quad.x2());
+                assertEquals(4, quad.y2());
+        }
+}


### PR DESCRIPTION
Adds support for Protocol V5, which is used by mod versions 5.0.0 and later.

**Changes:**
- New `ModSyncPacketV5` implementing V5 packet format with UV layout data
- Added UV layout classes (`UVLayouts`, `UVLayout`, `UVQuad`, `UVDirection`)
- Updated `ModSyncPacketV4` to reflect its actual version range (4.0.0 - 4.3.4)
- Added unit tests for protocol serialization round-trips
- Bumped plugin version to 1.5.0
- Updated README protocol table